### PR TITLE
商品一覧表示機能(一旦保存)

### DIFF
--- a/app/assets/stylesheets/items/index.css
+++ b/app/assets/stylesheets/items/index.css
@@ -258,6 +258,8 @@ a {
 .item-img {
   width: 33vh;
   height: 33vh;
+  background-size: cover;
+  background-position: center;
 }
 
 .sold-out {
@@ -290,12 +292,14 @@ a {
   font-size: 1.5vh;
   display: flex;
   justify-content: space-between;
+
 }
 
 
 .star-btn {
   display: flex;
   align-items: center;
+
 }
 
 .star-icon {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    @items= Item.all
+    @items= Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    #@item = Item.all
+    @items= Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,6 +129,7 @@
     </div>
 
     <ul class='item-lists'>
+
      <% if @items.present? %>
        <% @items.each do |item| %>
          <li class='list'>
@@ -143,44 +144,44 @@
           <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
-             <div class='item-info'>
-              <h3 class='item-name'><%= item.name %></h3>         
-               <div class='item-price'>
-                <%= "#{item.price}円" %><br><%= FeeBurden.find(item.fee_burden_id).name %>
-                   <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                      <span class='star-count'>0</span>
-                       </div>
-                          </div>
+        <div class='item-info'>
+          <h3 class='item-name'><%= item.name %></h3>         
+            <div class='item-price'>
+              <%= "#{item.price}円" %><br><%= FeeBurden.find(item.fee_burden_id).name %>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                   <span class='star-count'>0</span>
+                      </div>
+                        </div>
+                         </div>
                            </div>
-                             </div>
-                                </li>
-                                  <% end %>
-                            <% else %>
-                             <li class='list'>
-                               <%= link_to '#' do %>
-                                 <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-                                   <div class='item-info'>
-                                      <h3 class='item-name'>
-                                          商品を出品してね！
-                                            </h3>
-                                              <div class='item-price'>
-                                               <span>99999999円<br>(税込み)</span>
-                                                  <div class='star-btn'>
-                                                    <%= image_tag "star.png", class:"star-icon" %>
-                                                        <span class='star-count'>0</span>
-                                                     </div>
-                                                   </div>
-                                                </div>
-                                            <% end %>
-                                         <% end %>
-                                       </li>
-                                    </ul>
-                                </div>
-                     <%# /商品一覧 %>
-                    </div>
-                  <%= link_to new_item_path, class: 'purchase-btn' do %>
-                  <span class='purchase-btn-text'>出品する</span>
-               <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-            <% end %>
-      <%= render "shared/footer" %>
+                              </li>
+                               <% end %>
+                           <% else %>
+                          <li class='list'>
+                         <%= link_to '#' do %>
+                        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+                      <div class='item-info'>
+                     <h3 class='item-name'>
+                     商品を出品してね！
+                   </h3>
+                  <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+            <%= image_tag "star.png", class:"star-icon" %>
+           <span class='star-count'>0</span>
+         </div>
+        </div>
+       </div>
+      <% end %>
+     <% end %>
+   </li>
+  </ul>
+ </div>
+   <%# /商品一覧 %>
+     </div>
+      <%= link_to new_item_path, class: 'purchase-btn' do %>
+        <span class='purchase-btn-text'>出品する</span>
+         <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
+          <% end %>
+           <%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,64 +127,60 @@
     <div class="subtitle" >
       新規投稿商品
     </div>
+
     <ul class='item-lists'>
+     <% if @items.present? %>
+       <% @items.each do |item| %>
+         <li class='list'>
+          <div class="item-img-content">
+           <%= image_tag item.image, class: "item-img" %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+        <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <% if  item.order %>
+          <%# <div class='sold-out'> %>
+            <%# <span>Sold Out!!</span> %>
+          <%# </div> %>
+          <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
-  </div>
-  <%# /商品一覧 %>
-</div>
-<%= link_to new_item_path, class: 'purchase-btn' do %>
-  <span class='purchase-btn-text'>出品する</span>
-  <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-<% end %>
-<%= render "shared/footer" %>
+             <div class='item-info'>
+              <h3 class='item-name'><%= item.name %></h3>         
+               <div class='item-price'>
+                <%= "#{item.price}円" %><br><%= FeeBurden.find(item.fee_burden_id).name %>
+                   <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                       </div>
+                          </div>
+                           </div>
+                             </div>
+                                </li>
+                                  <% end %>
+                            <% else %>
+                             <li class='list'>
+                               <%= link_to '#' do %>
+                                 <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+                                   <div class='item-info'>
+                                      <h3 class='item-name'>
+                                          商品を出品してね！
+                                            </h3>
+                                              <div class='item-price'>
+                                               <span>99999999円<br>(税込み)</span>
+                                                  <div class='star-btn'>
+                                                    <%= image_tag "star.png", class:"star-icon" %>
+                                                        <span class='star-count'>0</span>
+                                                     </div>
+                                                   </div>
+                                                </div>
+                                            <% end %>
+                                         <% end %>
+                                       </li>
+                                    </ul>
+                                </div>
+                     <%# /商品一覧 %>
+                    </div>
+                  <%= link_to new_item_path, class: 'purchase-btn' do %>
+                  <span class='purchase-btn-text'>出品する</span>
+               <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
+            <% end %>
+      <%= render "shared/footer" %>


### PR DESCRIPTION
# What
商品一覧表示機能を作成

# Why
出品された商品はトップページに一覧で表示されるようにするため

現在まだ削除機能がないため、以下の動画しか確認できておりません。「売却済みの商品は、画像上に『sold out』の文字が表示されること」も未実装です。

↓商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/eb4227391b59da9e58c715acc531cb83